### PR TITLE
Fix problem with sequence stopping before finishing

### DIFF
--- a/src/actions/FadeTo.ts
+++ b/src/actions/FadeTo.ts
@@ -4,8 +4,6 @@ import Interpolation from '../Interpolation';
 import Interpolations from '../Interpolations';
 
 export default class FadeTo extends TargetedAction {
-	time: number = 0;
-	seconds: number;
 	interpolation: Interpolation;
 	startAlpha: number;
 	alpha: number;
@@ -16,8 +14,7 @@ export default class FadeTo extends TargetedAction {
 		seconds: number, 
 		interpolation: Interpolation = Interpolations.linear)
 	{
-		super(target);
-		this.seconds = seconds;
+		super(target, seconds);
 		this.interpolation = interpolation;
 		this.alpha = alpha;
 	}
@@ -29,9 +26,9 @@ export default class FadeTo extends TargetedAction {
 		
 		this.time += delta;
 		
-		const factor: number = this.interpolation(Math.min(1, this.time/this.seconds));
+		const factor: number = this.interpolation(this.timeDistance);
 		this.target.alpha = this.startAlpha + (this.alpha - this.startAlpha) * factor;
-		return factor >= 1;
+		return this.timeDistance >= 1;
 	}
 	
 	reset() {

--- a/src/actions/MoveTo.ts
+++ b/src/actions/MoveTo.ts
@@ -4,8 +4,6 @@ import Interpolation from '../Interpolation';
 import Interpolations from '../Interpolations';
 
 export default class MoveTo extends TargetedAction {
-	time: number = 0;
-	seconds: number;
 	interpolation: Interpolation;
 	startX: number;
 	startY: number;
@@ -19,8 +17,7 @@ export default class MoveTo extends TargetedAction {
 		seconds: number, 
 		interpolation: Interpolation = Interpolations.linear)
 	{
-		super(target);
-		this.seconds = seconds;
+		super(target, seconds);
 		this.interpolation = interpolation;
 		this.x = x;
 		this.y = y;
@@ -34,12 +31,12 @@ export default class MoveTo extends TargetedAction {
 		
 		this.time += delta;
 		
-		const factor: number = this.interpolation(Math.min(1, this.time/this.seconds));
+		const factor: number = this.interpolation(this.timeDistance);
 		this.target.position.set(
 			this.startX + (this.x - this.startX) * factor,
 			this.startY + (this.y - this.startY) * factor,
 		);
-		return factor >= 1;
+		return this.timeDistance >= 1;
 	}
 	
 	reset() {

--- a/src/actions/RotateTo.ts
+++ b/src/actions/RotateTo.ts
@@ -16,8 +16,7 @@ export default class RotateTo extends TargetedAction {
 		seconds: number, 
 		interpolation: Interpolation = Interpolations.linear)
 	{
-		super(target);
-		this.seconds = seconds;
+		super(target, seconds);
 		this.interpolation = interpolation;
 		this.rotation = rotation;
 	}
@@ -29,9 +28,9 @@ export default class RotateTo extends TargetedAction {
 		
 		this.time += delta;
 		
-		const factor: number = this.interpolation(Math.min(1, this.time/this.seconds));
+		const factor: number = this.interpolation(this.timeDistance);
 		this.target.rotation = this.startRotation + (this.rotation - this.startRotation) * factor;
-		return factor >= 1;
+		return this.timeDistance >= 1;
 	}
 	
 	reset() {

--- a/src/actions/ScaleTo.ts
+++ b/src/actions/ScaleTo.ts
@@ -4,8 +4,6 @@ import Interpolation from '../Interpolation';
 import Interpolations from '../Interpolations';
 
 export default class ScaleTo extends TargetedAction {
-	time: number = 0;
-	seconds: number;
 	interpolation: Interpolation;
 	startX: number;
 	startY: number;
@@ -19,8 +17,7 @@ export default class ScaleTo extends TargetedAction {
 		seconds: number, 
 		interpolation: Interpolation = Interpolations.linear)
 	{
-		super(target);
-		this.seconds = seconds;
+		super(target, seconds);
 		this.interpolation = interpolation;
 		this.x = x;
 		this.y = y;
@@ -34,12 +31,12 @@ export default class ScaleTo extends TargetedAction {
 		
 		this.time += delta;
 		
-		const factor: number = this.interpolation(Math.min(1, this.time/this.seconds));
+		const factor: number = this.interpolation(this.timeDistance);
 		this.target.scale.set(
 			this.startX + (this.x - this.startX) * factor,
 			this.startY + (this.y - this.startY) * factor,
 		);
-		return factor >= 1;
+		return this.timeDistance >= 1;
 	}
 	
 	reset() {

--- a/src/actions/TargetedAction.ts
+++ b/src/actions/TargetedAction.ts
@@ -3,10 +3,17 @@ import * as PIXI from 'pixi.js';
 import Action from './Action';
 
 export default abstract class TargetedAction extends Action {
+	time: number = 0;
+	seconds: number;
 	target: PIXI.DisplayObject;
 	
-	constructor(target: PIXI.DisplayObject) {
+	constructor(target: PIXI.DisplayObject, seconds: number) {
 		super();
+		this.seconds = seconds;
 		this.target = target;
+	}
+
+	get timeDistance(): number {
+		return Math.min(1, this.time / this.seconds)
 	}
 };


### PR DESCRIPTION
That can happen, when we add an interpolation method, that produces
slight rounding errors on `method(1)`, like that one:

```js
function easeInSine(x) {
  return 1 - Math.cos((x * Math.PI) / 2);
}
```

This fixes #1 