### PR TITLE
Export Action type, so users can hold vars with it

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import Actions from './Actions';
-import Interpolations from './Interpolations';
+import Actions from "./Actions";
+import Action from "./actions/Action";
+import Interpolations from "./Interpolations";
 
-export { Actions, Interpolations };
+export { Action, Actions, Interpolations };


### PR DESCRIPTION
Without that export, users of the lib, who want to store a action in a
variable have to either duplicate/copy that interface or use any. Both
options are not great. Let's make it convenient and less errorprone.